### PR TITLE
fluff: 在歷史頁面添加恢復此版本及合併en版回退

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -281,11 +281,11 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.openTalkPageOnAutoRevert (bool)
-			// Defines if talk page should be opened when calling revert from contrib page, because from there, actions may be multiple, and opening talk page not suitable. If set to true, openTalkPage defines then if talk page will be opened.
+			// Defines if talk page should be opened when calling revert from contribs or recent changes pages. If set to true, openTalkPage defines then if talk page will be opened.
 			{
 				name: 'openTalkPageOnAutoRevert',
-				label: wgULS('在从用户贡献中发起回退时打开用户讨论页', '在從使用者貢獻中發起回退時打開使用者討論頁'),
-				helptip: wgULS('您经常会在破坏者的用户贡献中发起许多回退，总是打开用户讨论页可能不太适当，所以这个选项默认关闭。当它打开时，依赖上一个设置。', '您經常會在破壞者的使用者貢獻中發起許多回退，總是打開使用者討論頁可能不太適當，所以這個選項預設關閉。當它打開時，依賴上一個設定。'),
+				label: wgULS('在从用户贡献及最近更改中发起回退时打开用户讨论页', '在從使用者貢獻及近期變更中發起回退時打開使用者討論頁'),
+				helptip: wgULS('当它打开时，依赖上一个设置。', '當它打開時，依賴上一個設定。'),
 				type: 'boolean'
 			},
 
@@ -324,7 +324,8 @@ Twinkle.config.sections = [
 			},
 
 			// TwinkleConfig.showRollbackLinks (array)
-			// Where Twinkle should show rollback links (diff, others, mine, contribs, recentchanges)
+			// Where Twinkle should show rollback links:
+			// diff, others, mine, contribs, history, recent
 			// Note from TTO: |contribs| seems to be equal to |others| + |mine|, i.e. redundant, so I left it out heres
 			{
 				name: 'showRollbackLinks',

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -179,7 +179,7 @@ Twinkle.fluff.addLinks = {
 				var vandNode = document.createElement('strong');
 				var normNode = document.createElement('strong');
 
-				var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', wgULS('回退（AGF）', '回退（AGF）'));
+				var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', '回退（AGF）');
 				var vandLink = Twinkle.fluff.buildLink('Red', wgULS('破坏', '破壞'));
 				var normLink = Twinkle.fluff.buildLink('SteelBlue', '回退');
 
@@ -327,7 +327,7 @@ Twinkle.fluff.addLinks = {
 			var vandNode = document.createElement('strong');
 			var normNode = document.createElement('strong');
 
-			var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', wgULS('回退（AGF）', '回退（AGF）'));
+			var agfLink = Twinkle.fluff.buildLink('DarkOliveGreen', '回退（AGF）');
 			var vandLink = Twinkle.fluff.buildLink('Red', wgULS('回退（破坏）', '回退（破壞）'));
 			var normLink = Twinkle.fluff.buildLink('SteelBlue', '回退');
 


### PR DESCRIPTION
https://github.com/azatoth/twinkle/commit/cdc5e3449845f1e176da80455c029fdc68e49cc9
新增在歷史頁面的所有版本添加恢復此版本按鈕。
在最近更改及相關更改的回退按鈕目前已有，不過從en合併以利之後持續更新。
與en不同的是，最近更改和相關更改可以分別啟用。