### PR TITLE
xfd: remove template change for vmv

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -401,9 +401,6 @@ Twinkle.xfd.callbacks = {
 				case 'vmq':
 				case 'vmvoy':
 				case 'vmv':
-					type = 'vm';
-					to = params.xfdcat;
-					break;
 				case 'fwdcsd':
 				case 'merge':
 					to = params.mergeinto;


### PR DESCRIPTION
站内现在已经有vmv的模板，无需再手动转换。