### PR TITLE
morebits.js: Fix redirect checking regex

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3258,7 +3258,7 @@ Morebits.wiki.page = function(pageName, currentAction) {
 			return; // abort
 		}
 
-		if (!ctx.lookupNonRedirectCreator || !/^\s*#(redirect|重定向|重新導向)/i.test($(xml).find('rev').text())) {
+		if (!ctx.lookupNonRedirectCreator || !/^\s*#(redirect|重定向|重新導向)/im.test($(xml).find('rev').text())) {
 
 			ctx.creator = $(xml).find('rev').attr('user');
 			if (!ctx.creator) {


### PR DESCRIPTION
Fix #55 
如果頁面中包含重定向，就將其當成重定向，不需要一定在第一行才視為重定向。
例如有人先提交了快速刪除，之後轉交存廢討論就會誤判為請求快速刪除的人為建立者。