### PR TITLE
stub: 移除enableStub偏好設定選項

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -570,11 +570,6 @@ Twinkle.config.sections = [
 		title: '小作品',
 		preferences: [
 			{
-				name: 'enableStub',
-				label: wgULS('启用这个功能', '啟用這個功能'),
-				type: 'boolean'
-			},
-			{
 				name: 'watchStubbedPages',
 				label: wgULS('标记时添加到监视列表', '標記時加入到監視清單'),
 				type: 'boolean'

--- a/modules/twinklestub.js
+++ b/modules/twinklestub.js
@@ -15,10 +15,6 @@
  */
 
 Twinkle.stub = function friendlytag() {
-	if (!Twinkle.getPref('enableStub')) {
-		return;
-	}
-
 	// redirect tagging
 	if (Morebits.wiki.isPageRedirect()) {
 		Twinkle.stub.mode = '重定向';

--- a/twinkle.js
+++ b/twinkle.js
@@ -148,7 +148,6 @@ Twinkle.defaultConfig = {
 	tagArticleSortOrder: 'cat',
 
 	// Stub
-	enableStub: true,
 	customTagList: [],
 	watchStubbedPages: false,
 	markStubbedPagesAsMinor: false,


### PR DESCRIPTION
已由更廣泛的disabledModules功能取代

於7/4後再合併