### PR TITLE
block: return false when checking if IP is a bot

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -159,8 +159,7 @@ Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
 			Twinkle.block.hasBlockLog = !!data.query.logevents.length;
 			// Used later to check if block status changed while filling out the form
 			Twinkle.block.blockLogId = Twinkle.block.hasBlockLog ? data.query.logevents[0].logid : false;
-
-			Twinkle.block.userIsBot = userinfo.groupmemberships.map(function(e) {
+			Twinkle.block.userIsBot = !userinfo.groupmemberships ? false : userinfo.groupmemberships.map(function(e) {
 				return e.group;
 			}).indexOf('bot') !== -1;
 


### PR DESCRIPTION
Twinkle.block.userIsBot检查IP时会抛出Cannot read property 'map' of undefined TypeError: Cannot read property 'map' of undefined的错误，造成封锁窗口无法展开。

如图：
![image](https://user-images.githubusercontent.com/39620264/86526154-beaa8300-bec2-11ea-98a2-1370020f7106.png)
