### PR TITLE
fluff: Actually use revertMaxRevisions, ignored for 13 years

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -360,7 +360,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		'prop': ['info', 'revisions'],
 		'titles': pagename,
 		'intestactions': 'edit',
-		'rvlimit': 50, // max possible
+		'rvlimit': Twinkle.getPref('revertMaxRevisions'),
 		'rvprop': [ 'ids', 'timestamp', 'user', 'comment' ],
 		'curtimestamp': '',
 		'meta': 'tokens',

--- a/twinkle.js
+++ b/twinkle.js
@@ -127,7 +127,7 @@ Twinkle.defaultConfig = {
 	markCopyvioPagesAsPatrolled: true,
 
 	// Hidden preferences
-	revertMaxRevisions: 50,
+	revertMaxRevisions: 50, // intentionally limited
 	batchMax: 5000,
 	batchdeleteChunks: 50,
 	batchProtectChunks: 50,


### PR DESCRIPTION
https://github.com/azatoth/twinkle/commit/14a104830c0d293f44e34a65c1bfc3272030b9b2
Close #94 