### PR TITLE
xfd: Don't setLookupNonRedirectCreator for modules

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -504,7 +504,9 @@ Twinkle.xfd.callbacks = {
 			// Notification to first contributor
 			var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'));
 			wikipedia_page.setCallbackParameters(pageobj.getCallbackParameters());
-			wikipedia_page.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
+			if (mw.config.get('wgPageContentModel') !== 'Scribunto') {
+				wikipedia_page.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
+			}
 			wikipedia_page.lookupCreator(Twinkle.xfd.callbacks.afd.main);
 		}
 	},


### PR DESCRIPTION
因為模組不可能有重定向，所以不要設定setLookupNonRedirectCreator以免錯誤
Fix #115 