### PR TITLE
Respect WP:LEADORDER when tagging

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -725,9 +725,8 @@ Twinkle.batchdelete.callbacks = {
 		}
 		var old_text = text;
 		var wikiPage = new Morebits.wikitext.page(text);
-		wikiPage.removeLink(params.page);
+		text = wikiPage.removeLink(params.page).getText();
 
-		text = wikiPage.getText();
 		Twinkle.batchdelete.unlinkCache[params.title] = text;
 		if (text === old_text) {
 			// Nothing to do, return
@@ -779,9 +778,8 @@ Twinkle.batchdelete.callbacks = {
 		}
 		var old_text = text;
 		var wikiPage = new Morebits.wikitext.page(text);
-		wikiPage.commentOutImage(image, wgULS('因文件已删，故注解', '因檔案已刪，故註解'));
+		text = wikiPage.commentOutImage(image, wgULS('因文件已删，故注解', '因檔案已刪，故註解')).getText();
 
-		text = wikiPage.getText();
 		Twinkle.batchdelete.unlinkCache[params.title] = text;
 		if (text === old_text) {
 			pageobj.getStatusElement().error(wgULS('在 ', '在 ') + pageobj.getPageName() + wgULS(' 上取消文件 ', ' 上取消檔案 ') + image + wgULS(' 链接失败', ' 連結失敗'));

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1375,45 +1375,29 @@ Twinkle.protect.callbacks = {
 				tag += '|small=yes';
 			}
 
-			if (params.noinclude) {
-				text = '<noinclude>{{' + tag + '}}</noinclude>' + text;
-			} else if (/^\s*#(redirect|重定向|重新導向)/i.test(text)) { // redirect page
-				text = text + '\n{{' + tag + '}}';
+			if (/^\s*#(?:redirect|重定向|重新導向)/i.test(text)) { // redirect page
+				// Only tag if no {{rcat shell}} is found
+				if (!text.match(/{{(?:Redirect[ _]category shell|Rcat[ _]shell|This[ _]is a redirect|多种类型重定向|多種類型重定向|多種類型重新導向|多种类型重新导向|R0|其他重定向|RCS|Redirect[ _]shell)/i)) {
+					text = text.replace(/#(?:redirect|重定向|重新導向) ?(\[\[.*?\]\])(.*)/i, '#REDIRECT $1$2\n\n{{' + tag + '}}');
+				} else {
+					Morebits.status.info('已存在Redirect category shell', wgULS('没什么可做的', '沒什麼可做的'));
+					return;
+				}
 			} else {
-				var firstSection, otherSection;
-				var index = text.indexOf('\n==');
-				if (index === -1) {
-					firstSection = text;
-					otherSection = '';
+				if (params.noinclude) {
+					tag = '<noinclude>{{' + tag + '}}</noinclude>';
+
+					// 只有表格需要单独加回车，其他情况加回车会破坏模板。
+					if (text.indexOf('{|') === 0) {
+						tag += '\n';
+					}
 				} else {
-					firstSection = text.substr(0, index);
-					otherSection = text.substr(index);
+					tag = '{{' + tag + '}}\n';
 				}
 
-				var dabTemplates = new RegExp('([\\s\\S]*(?:^|\\n)[ \\t]*{{\\s*(?:'
-					+ '(?:主条目消歧义|主條目消歧義|消歧义链接|消歧義鏈接|消歧義連結|消连|消連|消歧义连结|[Dd]isambLink|[Nn]oteref|[Dd]ablink)'
-					+ '|(?:[Rr]ellink|[Hh]atnote)'
-					+ '|(?:[Aa]bout|[Oo]theruses4|关于|關於)'
-					+ '|(?:[Ff]or)'
-					+ '|(?:[Ff]or2)'
-					+ '|(?:[Oo]ther[ _]uses|[Oo]theruse|条目消歧义|條目消歧義|他用|[Oo]theruses)'
-					+ '|(?:[Rr]edirect|重定向至此|[Rr]edirects[ _]here|[Rr]edirect[ _]to)'
-					+ '|(?:[Rr]edirect2|主條目消歧義2|主条目消歧义2|[Rr]edir|重定向至此2)'
-					+ '|(?:[Rr]edirect-multi)'
-					+ '|(?:[Rr]edirect3)'
-					+ '|(?:[Rr]edirect-synonym)'
-					+ '|(?:[Dd]istinguish|不是|[Nn]ot|提示|混淆|分別|分别|區別|区别|[Nn]OT|本条目的主题不是|本條目的主題不是|本条目主题不是|本條目主題不是|条目主题不是|條目主題不是)'
-					+ '|(?:[Dd]istinguish2|[Ss]elfDistinguish|[Ss]elfdistinguish|[Nn]ot2|不是2)'
-					+ '|(?:[Ss]elfref)'
-					+ '|(?:[Oo]ther[ _]places)'
-					+ '|(?:[Cc]ontrast|對比|对比)'
-					+ ')\\|.*}}[ \\t]*\\n)');
-
-				if (firstSection.match(dabTemplates)) {
-					text = firstSection.replace(dabTemplates, '$1{{' + tag + '}}\n') + otherSection;
-				} else {
-					text = '{{' + tag + '}}\n' + text;
-				}
+				// Insert tag after short description or any hatnotes
+				var wikipage = new Morebits.wikitext.page(text);
+				text = wikipage.insertAfterTemplates(tag, Twinkle.hatnoteRegex).getText();
 			}
 			summary = wgULS('添加{{' + params.tag + '}}', '加入{{' + params.tag + '}}') + Twinkle.getPref('summaryAd');
 		}

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1265,7 +1265,18 @@ Twinkle.speedy.callbacks = {
 				editsummary = wgULS('请求快速删除', '請求快速刪除') + '（[[WP:CSD#' + params.normalizeds[0].toUpperCase() + '|CSD ' + params.normalizeds[0].toUpperCase() + ']]）';
 			}
 
-			pageobj.setPageText(code + (params.blank ? '' : '\n' + text));
+
+			// Blank attack pages
+			if (params.blank) {
+				text = code;
+			} else {
+				// Insert tag after short description or any hatnotes
+				var wikipage = new Morebits.wikitext.page(text);
+				text = wikipage.insertAfterTemplates(code + '\n', Twinkle.hatnoteRegex).getText();
+			}
+
+
+			pageobj.setPageText(text);
 			pageobj.setEditSummary(editsummary + Twinkle.getPref('summaryAd'));
 			pageobj.setTags(Twinkle.getPref('revisionTags'));
 			pageobj.setWatchlist(params.watch);

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -268,21 +268,19 @@ Twinkle.unlink.callbacks = {
 
 		// remove image usages
 		if (params.doImageusage) {
-			wikiPage.commentOutImage(mw.config.get('wgTitle'), wgULS('注释出', '注釋出'));
-			text = wikiPage.getText();
+			text = wikiPage.commentOutImage(mw.config.get('wgTitle'), wgULS('注释', '注釋')).getText();
 			// did we actually make any changes?
 			if (text === oldtext) {
 				warningString = wgULS('文件使用', '檔案使用');
 			} else {
-				summaryText = wgULS('注释出文件使用', '注釋出檔案使用');
+				summaryText = wgULS('注释文件使用', '注釋檔案使用');
 				oldtext = text;
 			}
 		}
 
 		// remove backlinks
 		if (params.doBacklinks) {
-			wikiPage.removeLink(Morebits.pageNameNorm);
-			text = wikiPage.getText();
+			text = wikiPage.removeLink(Morebits.pageNameNorm).getText();
 			// did we actually make any changes?
 			if (text === oldtext) {
 				warningString = warningString ? wgULS('反链或文件使用', '反鏈或檔案使用') : wgULS('反链', '反鏈');

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -377,7 +377,11 @@ Twinkle.xfd.callbacks = {
 				pageobj.patrol();
 			}
 
-			pageobj.setPageText(tag + text);
+			// Insert tag after short description or any hatnotes
+			var wikipage = new Morebits.wikitext.page(text);
+			text = wikipage.insertAfterTemplates(tag, Twinkle.hatnoteRegex).getText();
+
+			pageobj.setPageText(text);
 			pageobj.setEditSummary(wgULS('页面存废讨论：[[', '頁面存廢討論：[[') + params.logpage + '#' + Morebits.pageNameNorm + ']]' + Twinkle.getPref('summaryAd'));
 			pageobj.setTags(Twinkle.getPref('revisionTags'));
 			switch (Twinkle.getPref('xfdWatchPage')) {


### PR DESCRIPTION
https://github.com/azatoth/twinkle/commit/40592a44443f7b27d44ccc14866ba9526bebf775
morebits.js 和 twinkle.js 已合併到 master branch，Labels 僅作紀錄
friendlytag.js 在 #121 處理